### PR TITLE
Fix bug getting value of a null object

### DIFF
--- a/src/Abstractor/Eloquent/Model.php
+++ b/src/Abstractor/Eloquent/Model.php
@@ -530,6 +530,10 @@ class Model implements ModelAbstractorContract
                 }
             }
 
+            if(is_null($entity))
+            {
+                return null;
+            }
             $lastRelationName = $relationName;
 
             array_pop($customColumnRelation);


### PR DESCRIPTION
In the list view a non necessary relation`s attribute could be retrieved. When it happens, instead to throw an exception a null value is returned to allow to render de list.